### PR TITLE
Notate about kernel version with I2C

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ sakuraio = SakuraIOSMBus()
 print(sakuraio.get_unique_id())
 ```
 
+*NOTE*
+
+DO NOT update linux kernel from `Linux raspberrypi 4.4.50-v7+`.
+
+It is reported that `OSError: [Errno 121] Remote I/O error` occurs with later version.
+
+
 #### SPI (GPIO)
 
 ```python


### PR DESCRIPTION
The error occurs with latest linux kernel.

```
Traceback (most recent call last):
  File “./getuniqid.py”, line 4, in <module>
    print(sakuraio.get_unique_id())
  File “/home/pi/.pyenv/versions/3.6.1/lib/python3.6/site-packages/sakuraio/hardware/commands/operation.py”, line 56, in get_unique_id
    return self.execute_command(CMD_GET_UNIQUE_ID, as_bytes=True).decode(“ascii”)
  File “/home/pi/.pyenv/versions/3.6.1/lib/python3.6/site-packages/sakuraio/hardware/base.py”, line 43, in execute_command
    self.start(False)
  File “/home/pi/.pyenv/versions/3.6.1/lib/python3.6/site-packages/sakuraio/hardware/rpi/__init__.py”, line 16, in start
    self.bus.write_i2c_block_data(SAKURAIO_SLAVE_ADDR, self.request[0], self.request[1:])
OSError: [Errno 121] Remote I/O error
```