### PR TITLE
Support auto typing enqueue

### DIFF
--- a/sakuraio/hardware/commands/transmit.py
+++ b/sakuraio/hardware/commands/transmit.py
@@ -1,7 +1,7 @@
 import struct
 import datetime
 
-from .utils import pack
+from .utils import pack, value_to_bytes
 
 # Transmit
 CMD_TX_ENQUEUE = 0x20
@@ -11,24 +11,6 @@ CMD_TX_CLEAR = 0x23
 CMD_TX_SEND = 0x24
 CMD_TX_STAT = 0x25
 
-def value_to_bytes(value):
-    """Convert value to raw values.
-
-    :param value:
-        Value to Convert
-    :type value: integer or float
-
-    :return: Tuple of `Type` string and `Value` list
-    :rtype: (str, list)
-    """
-
-    if isinstance(value, float):
-        return ("d", pack("<d", value))
-
-    if isinstance(value, int):
-        return ("l", pack("<q", value))
-
-    raise ValueError("Unsupported Type %s", value.__class__)
 
 class TransmitMixins(object):
 
@@ -89,7 +71,7 @@ class TransmitMixins(object):
 
         :param value:
             value to enqueue.
-        :type value: integer or float
+        :type value: integer, float, str or bytes
 
         :params int offset:
             Time offset in ms. Default ``0``. It must be less than or equal ``0``.
@@ -105,7 +87,7 @@ class TransmitMixins(object):
 
         :param value:
             value to enqueue.
-        :type value: integer or float
+        :type value: integer, float, str or bytes
         """
         t, data = value_to_bytes(value)
         self.send_immediate_raw(channel, t, data)

--- a/sakuraio/hardware/commands/transmit.py
+++ b/sakuraio/hardware/commands/transmit.py
@@ -11,6 +11,14 @@ CMD_TX_CLEAR = 0x23
 CMD_TX_SEND = 0x24
 CMD_TX_STAT = 0x25
 
+def value_to_bytes(value):
+    if isinstance(value, float):
+        return ("d", pack("<d", value))
+
+    if isinstance(value, int):
+        return ("l", pack("<q", value))
+
+    raise ValueError("Unsupported Type")
 
 class TransmitMixins(object):
 

--- a/sakuraio/hardware/commands/transmit.py
+++ b/sakuraio/hardware/commands/transmit.py
@@ -12,13 +12,23 @@ CMD_TX_SEND = 0x24
 CMD_TX_STAT = 0x25
 
 def value_to_bytes(value):
+    """Convert value to raw values.
+
+    :param value:
+        Value to Convert
+    :type value: integer or float
+
+    :return: Tuple of `Type` string and `Value` list
+    :rtype: (str, list)
+    """
+
     if isinstance(value, float):
         return ("d", pack("<d", value))
 
     if isinstance(value, int):
         return ("l", pack("<q", value))
 
-    raise ValueError("Unsupported Type")
+    raise ValueError("Unsupported Type %s", value.__class__)
 
 class TransmitMixins(object):
 
@@ -70,6 +80,35 @@ class TransmitMixins(object):
 
         request = [channel, ord(type)] + data[:8]
         self.execute_command(CMD_TX_SENDIMMED, request)
+
+    def enqueue_tx(self, channel, value, offset=0):
+        """Enqueue channel data by value.
+
+        :param int channel:
+            Channel number of data. Must be 0 to 127.
+
+        :param value:
+            value to enqueue.
+        :type value: integer or float
+
+        :params int offset:
+            Time offset in ms. Default ``0``. It must be less than or equal ``0``.
+        """
+        t, data = value_to_bytes(value)
+        self.enqueue_tx_raw(channel, t, data, offset)
+
+    def send_immediate(self, channel, value):
+        """Send channel data immediately by value.
+
+        :param int channel:
+            Channel number of data. Must be 0 to 127.
+
+        :param value:
+            value to enqueue.
+        :type value: integer or float
+        """
+        t, data = value_to_bytes(value)
+        self.send_immediate_raw(channel, t, data)
 
     def get_tx_queue_length(self):
         """Get available and queued length of tramsmit queue.

--- a/sakuraio/hardware/commands/utils.py
+++ b/sakuraio/hardware/commands/utils.py
@@ -1,5 +1,5 @@
 import struct
-
+import platform
 
 def pack(fmt, *args):
     """pack() is wrapper of struct.pack
@@ -39,7 +39,13 @@ def value_to_bytes(value):
         return ("l", pack("<q", value))
 
     if isinstance(value, str):
-        return ("b", (list(value.encode("utf-8"))+[0x00]*8)[:8])
+        if platform.python_version_tuple()[0] == "2":
+            result = []
+            for c in value.encode("utf-8"):
+                result.append(ord(c))
+            return ("b", (result+[0x00]*8)[:8])
+        else:
+            return ("b", (list(value.encode("utf-8"))+[0x00]*8)[:8])
 
     if isinstance(value, bytes):
         return ("b", (list(value)+[0x00]*8)[:8])

--- a/sakuraio/hardware/commands/utils.py
+++ b/sakuraio/hardware/commands/utils.py
@@ -20,3 +20,28 @@ def pack(fmt, *args):
         return result
     else:
         TypeError()
+
+def value_to_bytes(value):
+    """Convert value to raw values.
+
+    :param value:
+        Value to Convert
+    :type value: integer, float, str or bytes
+
+    :return: Tuple of `Type` string and `Value` list
+    :rtype: (str, list)
+    """
+
+    if isinstance(value, float):
+        return ("d", pack("<d", value))
+
+    if isinstance(value, int):
+        return ("l", pack("<q", value))
+
+    if isinstance(value, str):
+        return ("b", (list(value.encode("utf-8"))+[0x00]*8)[:8])
+
+    if isinstance(value, bytes):
+        return ("b", (list(value)+[0x00]*8)[:8])
+
+    raise ValueError("Unsupported Type %s", value.__class__)

--- a/sakuraio/hardware/commands/utils.py
+++ b/sakuraio/hardware/commands/utils.py
@@ -16,6 +16,7 @@ def pack(fmt, *args):
         return result
     elif isinstance(value, bytes):
         # For Python3
-        return value
+        result += value
+        return result
     else:
         TypeError()

--- a/sakuraio/hardware/commands/utils.py
+++ b/sakuraio/hardware/commands/utils.py
@@ -36,7 +36,12 @@ def value_to_bytes(value):
         return ("d", pack("<d", value))
 
     if isinstance(value, int):
+        if value > 9223372036854775807:
+            return ("L", pack("<Q", value))
         return ("l", pack("<q", value))
+
+    if platform.python_version_tuple()[0] == "2" and isinstance(value, long):
+        return ("L", pack("<Q", value))
 
     if isinstance(value, str):
         if platform.python_version_tuple()[0] == "2":

--- a/sakuraio/hardware/test/test_commands.py
+++ b/sakuraio/hardware/test/test_commands.py
@@ -3,7 +3,7 @@ import datetime
 
 from sakuraio.hardware.base import calc_parity
 from sakuraio.hardware.commands import *
-from sakuraio.hardware.commands.transmit import value_to_bytes
+from sakuraio.hardware.commands.utils import value_to_bytes
 from sakuraio.hardware.dummy import DummySakuraIO
 from sakuraio.hardware.exceptions import CommandError, ParityError
 
@@ -17,11 +17,6 @@ class CommandTest(unittest.TestCase):
         sakuraio.initial(payload)
 
         return sakuraio
-
-    def test_value_to_bytes(self):
-        self.assertEqual(value_to_bytes(0x12345678), ('l', [0x78, 0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00]))
-        self.assertEqual(value_to_bytes(-1), ('l', [255, 255, 255, 255, 255, 255, 255, 255]))
-        self.assertEqual(value_to_bytes(3.14), ('d', [31, 133, 235, 81, 184, 30, 9, 64]))
 
     def test_get_datetime(self):
         sakuraio = self._initial(0x01, [48, 78, 218, 39, 91, 1, 0, 0])

--- a/sakuraio/hardware/test/test_commands.py
+++ b/sakuraio/hardware/test/test_commands.py
@@ -3,9 +3,9 @@ import datetime
 
 from sakuraio.hardware.base import calc_parity
 from sakuraio.hardware.commands import *
+from sakuraio.hardware.commands.transmit import value_to_bytes
 from sakuraio.hardware.dummy import DummySakuraIO
 from sakuraio.hardware.exceptions import CommandError, ParityError
-
 
 class CommandTest(unittest.TestCase):
 
@@ -17,6 +17,11 @@ class CommandTest(unittest.TestCase):
         sakuraio.initial(payload)
 
         return sakuraio
+
+    def test_value_to_bytes(self):
+        self.assertEqual(value_to_bytes(0x12345678), ('l', [0x78, 0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00]))
+        self.assertEqual(value_to_bytes(-1), ('l', [255, 255, 255, 255, 255, 255, 255, 255]))
+        self.assertEqual(value_to_bytes(3.14), ('d', [31, 133, 235, 81, 184, 30, 9, 64]))
 
     def test_get_datetime(self):
         sakuraio = self._initial(0x01, [48, 78, 218, 39, 91, 1, 0, 0])

--- a/sakuraio/hardware/test/test_commands.py
+++ b/sakuraio/hardware/test/test_commands.py
@@ -45,10 +45,20 @@ class CommandTest(unittest.TestCase):
         sakuraio.enqueue_tx_raw(1, "i", [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08], -4321)
         self.assertEqual(sakuraio.values, [CMD_TX_ENQUEUE, 18, 1, 105, 1, 2, 3, 4, 5, 6, 7, 8, 31, 239, 255, 255, 255, 255, 255, 255, 162])
 
+    def test_enqueue_tx(self):
+        sakuraio = self._initial(0x01, [])
+        sakuraio.enqueue_tx(1, 0x0807060504030201)
+        self.assertEqual(sakuraio.values, [CMD_TX_ENQUEUE, 10, 1, 108, 1, 2, 3, 4, 5, 6, 7, 8, 79])
+
     def test_send_immediate_raw(self):
         sakuraio = self._initial(0x01, [])
         sakuraio.send_immediate_raw(1, "i", [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08])
         self.assertEqual(sakuraio.values, [CMD_TX_SENDIMMED, 10, 1, 105, 1, 2, 3, 4, 5, 6, 7, 8, 75])
+
+    def test_send_immediate_raw(self):
+        sakuraio = self._initial(0x01, [])
+        sakuraio.send_immediate(1, 0x0807060504030201)
+        self.assertEqual(sakuraio.values, [CMD_TX_SENDIMMED, 10, 1, 108, 1, 2, 3, 4, 5, 6, 7, 8, 78])
 
     def test_get_tx_queue_length(self):
         sakuraio = self._initial(0x01, [23, 14])

--- a/sakuraio/hardware/test/test_utils.py
+++ b/sakuraio/hardware/test/test_utils.py
@@ -7,6 +7,8 @@ class UtilsTest(unittest.TestCase):
     def test_value_to_bytes(self):
         self.assertEqual(value_to_bytes(0x12345678), ('l', [0x78, 0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00]))
         self.assertEqual(value_to_bytes(-1), ('l', [255, 255, 255, 255, 255, 255, 255, 255]))
+        self.assertEqual(value_to_bytes(9223372036854775807), ('l', [255, 255, 255, 255, 255, 255, 255, 127]))
+        self.assertEqual(value_to_bytes(9223372036854775808), ('L', [0, 0, 0, 0, 0, 0, 0, 128]))
         self.assertEqual(value_to_bytes(3.14), ('d', [31, 133, 235, 81, 184, 30, 9, 64]))
         self.assertEqual(value_to_bytes("Hello"), ('b', [72, 101, 108, 108, 111, 0, 0, 0]))
         self.assertEqual(value_to_bytes("Hello World"), ('b', [72, 101, 108, 108, 111, 32, 87, 111]))

--- a/sakuraio/hardware/test/test_utils.py
+++ b/sakuraio/hardware/test/test_utils.py
@@ -1,0 +1,13 @@
+import unittest
+
+from sakuraio.hardware.commands.utils import value_to_bytes
+
+class UtilsTest(unittest.TestCase):
+
+    def test_value_to_bytes(self):
+        self.assertEqual(value_to_bytes(0x12345678), ('l', [0x78, 0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00]))
+        self.assertEqual(value_to_bytes(-1), ('l', [255, 255, 255, 255, 255, 255, 255, 255]))
+        self.assertEqual(value_to_bytes(3.14), ('d', [31, 133, 235, 81, 184, 30, 9, 64]))
+        self.assertEqual(value_to_bytes("Hello"), ('b', [72, 101, 108, 108, 111, 0, 0, 0]))
+        self.assertEqual(value_to_bytes("Hello World"), ('b', [72, 101, 108, 108, 111, 32, 87, 111]))
+        self.assertEqual(value_to_bytes(b"Hello"), ('b', [72, 101, 108, 108, 111, 0, 0, 0]))


### PR DESCRIPTION
  # New methods

```python
sakuraio.enqueue_tx(1, 12345) # treat as "l"
sakuraio.enqueue_tx(1, 3.14) # treat as "d"
sakuraio.enqueue_tx(1, "Hello") # treat as "b"
sakuraio.enqueue_tx(1, b"\x00\x01\x02\x03") # treat as "b"
```

`send_immediate()` is same `enqueue_tx()`