### PR TITLE
Change argument of start_file_download() and get_file_data() to int from list

### DIFF
--- a/sakuraio/hardware/commands/file.py
+++ b/sakuraio/hardware/commands/file.py
@@ -14,13 +14,16 @@ class FileMixins(object):
     def start_file_download(self, fileid):
         """Start file download
 
-        :param list fileid:
-            FileID. List length must be 1, the Value fileid[0] must be 1 to 5.
+        :param integer fileid:
+            FileID of start to download, must be 1 to 5.
 
         """
 
-        fileid += [0x00] * 2
-        self.execute_command(CMD_START_FILE_DOWNLOAD, fileid[:2])
+        if isinstance(fileid, list):
+            # for Compatibility
+            fileid = fileid[0]
+
+        self.execute_command(CMD_START_FILE_DOWNLOAD, [fileid, 0x00])
 
     def get_file_metadata(self):
         """Get file metadata
@@ -58,11 +61,25 @@ class FileMixins(object):
     def get_file_data(self, rsize):
         """Get file data
 
-        :return: Dict of download file body.abs
-        :rtype: dict
+        :param integer rsize:
+            Max receive size, must be 1 to 255.
+
+        :return: Part of data
+        :rtype: list
         """
 
-        response = self.execute_command(CMD_GET_FILE_DATA, rsize[0:1])
-        return {
-            "data": response[0:]
-        }
+        is_old_style = False
+
+        if isinstance(rsize, list):
+            rsize = rsize[0]
+            is_old_style = True
+
+        if rsize <= 0 or rsize > 255:
+            raise ValueError("Invalid rsize %d", rsize)
+
+        response = self.execute_command(CMD_GET_FILE_DATA, [rsize])
+        if is_old_style:
+            return {
+                "data": response[0:]
+            }
+        return response

--- a/sakuraio/hardware/test/test_commands.py
+++ b/sakuraio/hardware/test/test_commands.py
@@ -85,6 +85,39 @@ class CommandTest(unittest.TestCase):
         sakuraio.clear_rx()
         self.assertEqual(sakuraio.values, [CMD_RX_CLEAR, 0, CMD_RX_CLEAR])
 
+    def test_start_file_download(self):
+        sakuraio = self._initial(0x01, [])
+        sakuraio.start_file_download(1)
+        self.assertEqual(sakuraio.values, [CMD_START_FILE_DOWNLOAD, 2, 0x01, 0x00, 67])
+
+        # for Compatibility
+        sakuraio = self._initial(0x01, [])
+        sakuraio.start_file_download([1])
+        self.assertEqual(sakuraio.values, [CMD_START_FILE_DOWNLOAD, 2, 0x01, 0x00, 67])
+
+    def test_get_file_download_status(self):
+        sakuraio = self._initial(0x01, [0, 0x01, 0x02, 0x03, 0x04])
+        result = sakuraio.get_file_download_status()
+        self.assertEqual(sakuraio.values, [CMD_GET_FILE_DOWNLOAD_STATUS, 0, CMD_GET_FILE_DOWNLOAD_STATUS])
+        self.assertEqual(result, {'status': 0, 'size': 0x04030201})
+
+    def test_cancel_file_download(self):
+        sakuraio = self._initial(0x01, [])
+        result = sakuraio.cancel_file_download()
+        self.assertEqual(sakuraio.values, [CMD_CANCEL_FILE_DOWNLOAD, 0, CMD_CANCEL_FILE_DOWNLOAD])
+
+    def test_get_file_data(self):
+        sakuraio = self._initial(0x01, [0x01, 0x02, 0x03, 0x04, 0x05])
+        result = sakuraio.get_file_data(128)
+        self.assertEqual(sakuraio.values, [CMD_GET_FILE_DATA, 1, 128, 197])
+        self.assertEqual(result, [0x01, 0x02, 0x03, 0x04, 0x05])
+
+        # for Compatibility
+        sakuraio = self._initial(0x01, [0x01, 0x02, 0x03, 0x04, 0x05])
+        result = sakuraio.get_file_data([128])
+        self.assertEqual(sakuraio.values, [CMD_GET_FILE_DATA, 1, 128, 197])
+        self.assertEqual(result, {"data":[0x01, 0x02, 0x03, 0x04, 0x05]})
+
     def test_get_product_id(self):
         sakuraio = self._initial(0x01, [0x02, 0x00])
         self.assertEqual(sakuraio.get_product_id(), 2)


### PR DESCRIPTION
# Old

```python
sakuraio.start_file_download([2])
sakuraio.get_file_data([128])
```

# New

```python
sakuraio.start_file_download(2)
sakuraio.get_file_data(128)
```

# Note

Compatibility is maintained.